### PR TITLE
bumped version number because Nvidia removed their old version tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM debian
-FROM docker.io/nvidia/cuda:11.4.1-cudnn8-devel-ubuntu20.04
+FROM docker.io/nvidia/cuda:11.4.3-cudnn8-devel-ubuntu20.04
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install git ffmpeg python3-pip python3
 


### PR DESCRIPTION
Nvidia removed the `cuda:11.4.1-cudnn8-devel-ubuntu20.04` tag.